### PR TITLE
Add ssom for stable systems (Hankel singular value)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.3.2"
 
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
 FlightSims = "a4c2f6ca-3fbe-4430-8ede-32935de4c069"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FaultTolerantControl.jl
+++ b/src/FaultTolerantControl.jl
@@ -15,6 +15,7 @@ using Transducers, UnPack, ComponentArrays
 import SplitApplyCombine
 import MatrixEquations
 using NumericalIntegration
+using ControlSystems: ss, gram
 
 # Fault
 export AbstractFault, FaultSet
@@ -28,10 +29,13 @@ export Bezier
 # cost functional
 export PositionAngularVelocityCostFunctional
 export cost
+# reconfigurability
+export ssom
 
 
 include("utils.jl")
 include("costs.jl")
+include("reconfigurability.jl")
 include("faults.jl")
 include("environments/environments.jl")
 include("trajectory_generation.jl")

--- a/src/reconfigurability.jl
+++ b/src/reconfigurability.jl
@@ -1,0 +1,20 @@
+"""
+Get the smallest second-order mode (ssom) for linear time-invariant (LTI) systems.
+
+# Refs
+[1] N. E. Wu, K. Zhou, and G. Salomon, “Control Reconfigurability of Linear Time-Invariant Systems,” p. 5, 2000.
+"""
+function ssom(A, B, C, D=zeros(size(C)[1], size(B)[2]))
+    # Note: ss, gram exported from `ControlSystems.jl`
+    if all(real.(eigvals(A)) .< 0)  # Hurwitz matrix
+        sys = ss(A, B, C, D)
+        Wc = gram(sys, :c)
+        Wo = gram(sys, :o)
+        # Hankel singular value (HSV)
+        # TODO: HSV is only valid for stable `sys`; otherwise, `gram` does not work.
+        return hsv_min = Wc*Wo |> LinearAlgebra.eigvals |> minimum |> sqrt
+    else
+        error("TODO: ssom for unstable systems has not been developed yet.")
+        # TODO: [1, Eqs. (7-8)]
+    end
+end

--- a/test/reconfigurability.jl
+++ b/test/reconfigurability.jl
@@ -1,0 +1,32 @@
+using FaultTolerantControl
+using Test
+
+
+@testset "reconfigurability" begin
+    # [1, Section 3, example 1]
+    # # Refs
+    # [1] N. E. Wu, K. Zhou, and G. Salomon, “Control Reconfigurability of Linear Time-Invariant Systems,” p. 5, 2000.
+    A = [
+         -0.0226 -36.6 -18.9 -32.1;
+         0 -1.9 0.983 0;
+         0.0123 -11.7 -2.63 0;
+         0 0 1 0;
+        ]
+    B = [
+         0 0;
+         -0.414 0;
+         -77.8 22.4;
+         0 0;
+        ]
+    C = [
+         0 5.73 0 0;
+         0 0 0 5.73;
+        ]
+    D = [
+         0 0;
+         0 0;
+        ]
+    n = size(B)[1]
+    ssom_min = ssom(A, B, C, D)
+    @test ssom_min >= 10 && ssom_min < 12
+end


### PR DESCRIPTION
Resolves https://github.com/JinraeKim/FTCTests.jl/issues/60.

`ssom` stands for "the smallest second-order modes" [1].

[1] [N. E. Wu, K. Zhou, and G. Salomon, “Control Reconfigurability of Linear Time-Invariant Systems,” p. 5, 2000.](https://www.sciencedirect.com/science/article/pii/S0005109800000807?via%3Dihub)