### PR TITLE
Tune simulation parameters for comparing empirical gramian with gramian

### DIFF
--- a/test/reconfigurability.jl
+++ b/test/reconfigurability.jl
@@ -52,12 +52,13 @@ end
     x0 = [0.0, 0.0, 0.0, 0.0]
     u0 = [0.0]
 
-    empirical_Wc = empirical_gramian(f, g, m, n, l; opt=:c, dt=0.01, tf=1.0, pr=zeros(4, 1), xs=x0, us=u0)
-    empirical_Wo = empirical_gramian(f, g, m, n, l; opt=:o, dt=0.01, tf=1.0, pr=zeros(4, 1), xs=x0, us=u0)
+    empirical_Wc = empirical_gramian(f, g, m, n, l; opt=:c, dt=0.01, tf=5.0, pr=zeros(4, 1), xs=x0, us=u0)
+    empirical_Wo = empirical_gramian(f, g, m, n, l; opt=:o, dt=0.01, tf=5.0, pr=zeros(4, 1), xs=x0, us=u0)
 	minHSV = min_HSV(Wc, Wo)
 	@show empirical_Wc empirical_Wo minHSV
     sys = ss(A, B, C, D)
     Wc = gram(sys, :c)
     Wo = gram(sys, :o)
+    @show Wc Wo
     @test norm(Wc-empirical_Wc) < 1.0 && norm(Wo-empirical_Wo) < 1.0
 end

--- a/test/reconfigurability.jl
+++ b/test/reconfigurability.jl
@@ -54,11 +54,12 @@ end
 
     empirical_Wc = empirical_gramian(f, g, m, n, l; opt=:c, dt=0.01, tf=5.0, pr=zeros(4, 1), xs=x0, us=u0)
     empirical_Wo = empirical_gramian(f, g, m, n, l; opt=:o, dt=0.01, tf=5.0, pr=zeros(4, 1), xs=x0, us=u0)
-	minHSV = min_HSV(Wc, Wo)
-	@show empirical_Wc empirical_Wo minHSV
+    minHSV = min_HSV(empirical_Wc, empirical_Wo)
+    # @show empirical_Wc empirical_Wo minHSV
     sys = ss(A, B, C, D)
     Wc = gram(sys, :c)
     Wo = gram(sys, :o)
-    @show Wc Wo
-    @test norm(Wc-empirical_Wc) < 1.0 && norm(Wo-empirical_Wo) < 1.0
+    eps = 1e-2
+    @test isapprox(norm(empirical_Wc), norm(Wc), atol=eps)
+    @test isapprox(norm(empirical_Wo), norm(Wo), atol=eps)
 end


### PR DESCRIPTION
Resolves https://github.com/JinraeKim/FTCTests.jl/issues/69.

시뮬레이션 파라미터를 수정하여 empirical gramian과 gramian이 유사한 값을 갖도록 함.
- `tf` 값을 수정하여 유사한 결과를 낼 수 있음
- `tf` 값이 더 커질수록 gramian 값에 수렴하는 것처럼 보임

### Results
- `tf = 1.0` -> `tf = 2.0`
```julia
empirical_Wc = [0.0 0.0 0.0 0.0; 0.0 0.4908336727138013 0.0 0.4908336727138013; 0.0 0.0 0.0 0.0; 0.0 0.4908336727138013 0.0 0.4908336727138013]
empirical_Wo = [0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.4959539270484408 0.4959539270484408; 0.0 0.0 0.4959539270484408 0.4959539270484408]
Wc = [0.0 0.0 0.0 0.0; 0.0 0.5000000000000001 0.0 0.5; 0.0 0.0 0.0 0.0; 0.0 0.5 0.0 0.4999999999999999]
Wo = [0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.5000000000000001 0.5000000000000001; 0.0 0.0 0.5000000000000001 0.5000000000000001]
```
- `tf = 1.0` -> `tf = 5.0`
```julia
empirical_Wc = [0.0 0.0 0.0 0.0; 0.0 0.49996894445139667 0.0 0.49996894445139667; 0.0 0.0 0.0 0.0; 0.0 0.49996894445139667 0.0 0.49996894445139667]
empirical_Wo = [0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.5049983781982454 0.5049983781982454; 0.0 0.0 0.5049983781982454 0.5049983781982454]
Wc = [0.0 0.0 0.0 0.0; 0.0 0.5000000000000001 0.0 0.5; 0.0 0.0 0.0 0.0; 0.0 0.5 0.0 0.4999999999999999]
Wo = [0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.5000000000000001 0.5000000000000001; 0.0 0.0 0.5000000000000001 0.5000000000000001]
```
- `tf = 1.0` -> `tf = 10.0`
```julia
empirical_Wc = [0.0 0.0 0.0 0.0; 0.0 0.4999916449074608 0.0 0.4999916449074608; 0.0 0.0 0.0 0.0; 0.0 0.4999916449074608 0.0 0.4999916449074608]
empirical_Wo = [0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.5050208529720502 0.5050208529720502; 0.0 0.0 0.5050208529720502 0.5050208529720502]
Wc = [0.0 0.0 0.0 0.0; 0.0 0.5000000000000001 0.0 0.5; 0.0 0.0 0.0 0.0; 0.0 0.5 0.0 0.4999999999999999]
Wo = [0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0; 0.0 0.0 0.5000000000000001 0.5000000000000001; 0.0 0.0 0.5000000000000001 0.5000000000000001]
```

참고: #62 를 머지한 후에 머지해야 함.